### PR TITLE
Move pypi-token requirement from 'make setup' to 'make publish'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 setup:
 	@pip install -U pip poetry
-	@poetry config pypi-token.pypi $(PYPI_API_TOKEN)
 
 dependencies:
 	@make setup
@@ -33,6 +32,7 @@ publish:
 	@make clean
 	@printf "\nPublishing lib"
 	@make setup
+	@poetry config pypi-token.pypi $(PYPI_API_TOKEN)
 	@poetry publish --build
 	@make clean
 


### PR DESCRIPTION
Running make dependencies it's raised an error when trying to get pypi-token from local envs. But, this env is used just on `make publish`.

![image](https://user-images.githubusercontent.com/26297247/131695536-fe3948d4-829b-4fc5-a37c-fd7b041861b8.png)
