### PR TITLE
chore: handle "channelIdNotUnique" calendar watch error

### DIFF
--- a/gcp_pilot/base.py
+++ b/gcp_pilot/base.py
@@ -303,6 +303,7 @@ def friendly_http_error(func):
         "forbidden": exceptions.NotAllowed,
         "duplicate": exceptions.AlreadyExists,
         "push.webhookUrlUnauthorized": exceptions.PushWebhookInvalid,
+        "channelIdNotUnique": exceptions.ChannelIdNotUnique,
     }
     _statuses = {
         "INVALID_ARGUMENT": exceptions.ValidationError,

--- a/gcp_pilot/exceptions.py
+++ b/gcp_pilot/exceptions.py
@@ -51,3 +51,7 @@ class MissingUserIdentification(Exception):
 
 class PushWebhookInvalid(ValidationError):
     pass
+
+
+class ChannelIdNotUnique(Exception):
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcp-pilot"
-version = "0.32.0"
+version = "0.32.1"
 description = "Google Cloud Platform Friendly Pilot"
 authors = ["Joao Daher <joao@daher.dev>"]
 repository = "https://github.com/flamingo-run/gcp-pilot"


### PR DESCRIPTION
This handles the response like:
```
{
  'code': 400,
  'errors': [{'domain': 'push',
              'message': 'Channel id cogsworth-api-dev--23 not unique',
              'reason': 'channelIdNotUnique'}],
  'message': 'Channel id cogsworth-api-dev--23 not unique'
}
 ```
