### PR TITLE
feat: add support to _include and _revinclude in FHIR pagination

### DIFF
--- a/gcp_pilot/healthcare.py
+++ b/gcp_pilot/healthcare.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import parse_qsl, urlsplit
 
+from fhir.resources import get_fhir_model_class
 from fhir.resources.domainresource import DomainResource
 from fhir.resources.identifier import Identifier
 
@@ -174,7 +175,8 @@ class FHIRResultSet:
             return
 
         for entry in self.response["entry"]:
-            yield self.resource_class(**entry["resource"])
+            resource_class = get_fhir_model_class(entry["resource"]["resourceType"])
+            yield resource_class(**entry["resource"])
 
     @property
     def next_cursor(self) -> str | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcp-pilot"
-version = "1.27.0"
+version = "1.28.0"
 description = "Google Cloud Platform Friendly Pilot"
 authors = ["Joao Daher <joao@daher.dev>"]
 repository = "https://github.com/flamingo-run/gcp-pilot"


### PR DESCRIPTION
A request with the  `_include` or `_revinclude` parameter can return different types of FHIR resources in the response.