### PR TITLE
feat: Add retry configuration to Cloud Tasks push

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gcp-pilot"
-version = "1.33.0"
+version = "1.34.0"
 description = "Google Cloud Platform Friendly Pilot"
 authors = [
     {name = "Joao Daher", email = "joao@daher.dev"},


### PR DESCRIPTION
Allows users to specify a custom retry strategy when creating tasks via the `push` method in the `CloudTasks` client.

This provides more control over task creation resilience by enabling customization of retry behavior, such as backoff times and retryable conditions. The default behavior uses the Google API client's default retry settings.