### PR TITLE
FIX FHIR result set resource type

### DIFF
--- a/gcp_pilot/healthcare.py
+++ b/gcp_pilot/healthcare.py
@@ -175,7 +175,7 @@ class FHIRResultSet:
             return
 
         for entry in self.response["entry"]:
-            resource_class = get_fhir_model_class(entry["resource"]["resourceType"])
+            resource_class = self.resource_class or get_fhir_model_class(entry["resource"]["resourceType"])
             yield resource_class(**entry["resource"])
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gcp-pilot"
-version = "1.34.0"
+version = "1.34.1"
 description = "Google Cloud Platform Friendly Pilot"
 authors = [
     {name = "Joao Daher", email = "joao@daher.dev"},


### PR DESCRIPTION
When using FHIR R4 models in the resource_type parameter, it is always ignored and instantiates the latest model version (current is R5).
