### PR TITLE
feat: add bulk_create and auto-split batches

### DIFF
--- a/gcp_pilot/firestore/atomic.py
+++ b/gcp_pilot/firestore/atomic.py
@@ -11,9 +11,14 @@ from google.cloud.firestore_v1.async_client import AsyncClient
 if TYPE_CHECKING:
     from gcp_pilot.firestore.document import Document
 
+MAX_OPS = 450  # Firestore limit is 500; leave margin
+
 
 class _Batch:
-    """Wraps an AsyncWriteBatch bound to a specific model's database."""
+    """Wraps an AsyncWriteBatch bound to a specific model's database.
+
+    Automatically commits and starts a new batch when reaching MAX_OPS.
+    """
 
     def __init__(self, model: type[Document]) -> None:
         self._model = model
@@ -21,6 +26,7 @@ class _Batch:
         self._project_id: str | None = model._meta.project_id
         self._client: AsyncClient = model.documents.client
         self._batch: AsyncWriteBatch = self._client.batch()
+        self._op_count: int = 0
 
     def _check_model(self, client: AsyncClient) -> None:
         if client is not self._client:
@@ -29,20 +35,36 @@ class _Batch:
                 f"This batch is bound to database '{self._database_id}'."
             )
 
-    def set(self, doc_ref, fields, client: AsyncClient) -> None:
+    async def _flush(self) -> None:
+        """Commit current batch and start a new one."""
+        await self._batch.commit()
+        self._batch = self._client.batch()
+        self._op_count = 0
+
+    async def set(self, doc_ref, fields, client: AsyncClient) -> None:
         self._check_model(client)
+        if self._op_count >= MAX_OPS:
+            await self._flush()
         self._batch.set(doc_ref, fields)
+        self._op_count += 1
 
-    def update(self, doc_ref, fields, client: AsyncClient) -> None:
+    async def update(self, doc_ref, fields, client: AsyncClient) -> None:
         self._check_model(client)
+        if self._op_count >= MAX_OPS:
+            await self._flush()
         self._batch.update(doc_ref, fields)
+        self._op_count += 1
 
-    def delete(self, doc_ref, client: AsyncClient) -> None:
+    async def delete(self, doc_ref, client: AsyncClient) -> None:
         self._check_model(client)
+        if self._op_count >= MAX_OPS:
+            await self._flush()
         self._batch.delete(doc_ref)
+        self._op_count += 1
 
     async def commit(self) -> None:
-        await self._batch.commit()
+        if self._op_count > 0:
+            await self._batch.commit()
 
 
 _active_batch: contextvars.ContextVar[_Batch | None] = contextvars.ContextVar("_active_batch", default=None)
@@ -53,7 +75,8 @@ async def batch(model: type[Document]) -> AsyncGenerator[None]:
     """Context manager for batching Firestore writes.
 
     All operations inside the batch must belong to the same database
-    as the given model.
+    as the given model. Automatically splits into multiple batches
+    if the number of operations exceeds the Firestore limit.
 
     Usage:
         async with atomic.batch(Product):

--- a/gcp_pilot/firestore/manager.py
+++ b/gcp_pilot/firestore/manager.py
@@ -8,7 +8,7 @@ from google.cloud import firestore
 from google.cloud.firestore_v1.async_client import AsyncClient
 from google.cloud.firestore_v1.async_collection import AsyncCollectionReference
 
-from gcp_pilot.firestore.atomic import _active_batch
+from gcp_pilot.firestore.atomic import _active_batch, _Batch
 from gcp_pilot.firestore.exceptions import DoesNotExist
 from gcp_pilot.firestore.fqn import FQN
 from gcp_pilot.firestore.query import Query
@@ -122,7 +122,7 @@ class Manager:
         fields = self._normalize_for_firestore(fields)
         batch = _active_batch.get()
         if batch is not None:
-            batch.set(doc_ref, fields, client=self.client)
+            await batch.set(doc_ref, fields, client=self.client)
             # Cannot fetch snapshot before commit; build document without using _to_document
             payload = {"id": doc_ref.id, **fields}
             document = self.doc_klass.model_validate(payload)
@@ -151,7 +151,7 @@ class Manager:
         fields = self._normalize_for_firestore(fields)
         batch = _active_batch.get()
         if batch is not None:
-            batch.update(doc_ref, fields, client=self.client)
+            await batch.update(doc_ref, fields, client=self.client)
         else:
             await doc_ref.update(fields)
 
@@ -159,9 +159,36 @@ class Manager:
         doc_ref = self.collection.document(id)
         batch = _active_batch.get()
         if batch is not None:
-            batch.delete(doc_ref, client=self.client)
+            await batch.delete(doc_ref, client=self.client)
         else:
             await doc_ref.delete()
+
+    async def bulk_create(self, items: list[dict[str, Any]]) -> int:
+        """Batch-create documents efficiently with automatic splitting.
+
+        Each item dict may include an ``id`` key for deterministic document IDs.
+        Uses Firestore set() semantics (upsert).
+
+        Args:
+            items: List of field dictionaries to write.
+
+        Returns:
+            Number of documents written.
+        """
+        if _active_batch.get() is not None:
+            raise RuntimeError("bulk_create cannot be used inside an atomic.batch() context.")
+
+        b = _Batch(self.doc_klass)
+        count = 0
+        for item in items:
+            fields = dict(item)
+            doc_id = fields.pop("id", None)
+            doc_ref = self.collection.document(doc_id)
+            fields = self._normalize_for_firestore(fields)
+            await b.set(doc_ref, fields, client=self.client)
+            count += 1
+        await b.commit()
+        return count
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._get_query(), name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gcp-pilot"
-version = "1.40.0"
+version = "1.41.0"
 description = "Google Cloud Platform Friendly Pilot"
 authors = [
     {name = "Joao Daher", email = "joao@daher.dev"},

--- a/tests/gcp_pilot/firestore_test/bulk_write_test.py
+++ b/tests/gcp_pilot/firestore_test/bulk_write_test.py
@@ -1,0 +1,59 @@
+import pytest
+
+from gcp_pilot.firestore import atomic
+from gcp_pilot.firestore.atomic import MAX_OPS
+from tests.gcp_pilot.firestore_test.conftest import Product
+
+
+@pytest.mark.asyncio
+class TestBulkCreate:
+    async def test_basic(self):
+        items = [{"name": f"Product {i}", "price": float(i)} for i in range(5)]
+        count = await Product.documents.bulk_create(items)
+
+        assert count == 5
+        products = [p async for p in Product.documents.filter()]
+        assert len(products) == 5
+
+    async def test_with_ids(self):
+        items = [
+            {"id": "custom-1", "name": "Product 1", "price": 10.0},
+            {"id": "custom-2", "name": "Product 2", "price": 20.0},
+        ]
+        count = await Product.documents.bulk_create(items)
+
+        assert count == 2
+        p1 = await Product.documents.get(id="custom-1")
+        assert p1.name == "Product 1"
+        p2 = await Product.documents.get(id="custom-2")
+        assert p2.name == "Product 2"
+
+    async def test_auto_split(self):
+        n = MAX_OPS + 100
+        items = [{"name": f"Product {i}", "price": float(i)} for i in range(n)]
+        count = await Product.documents.bulk_create(items)
+
+        assert count == n
+        total = await Product.documents.count()
+        assert total == n
+
+    async def test_inside_batch_raises(self):
+        with pytest.raises(RuntimeError, match="bulk_create cannot be used inside"):
+            async with atomic.batch(Product):
+                await Product.documents.bulk_create([{"name": "X", "price": 1.0}])
+
+    async def test_empty_list(self):
+        count = await Product.documents.bulk_create([])
+        assert count == 0
+
+
+@pytest.mark.asyncio
+class TestBatchAutoSplit:
+    async def test_batch_exceeding_limit(self):
+        n = MAX_OPS + 100
+        async with atomic.batch(Product):
+            for i in range(n):
+                await Product.documents.create(name=f"Product {i}", price=float(i))
+
+        total = await Product.documents.count()
+        assert total == n

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ wheels = [
 
 [[package]]
 name = "gcp-pilot"
-version = "1.40.0"
+version = "1.41.0"
 source = { virtual = "." }
 dependencies = [
     { name = "factory-boy" },


### PR DESCRIPTION
## Summary
- `Manager.bulk_create(items)` for efficient bulk writes with automatic batch splitting
- `_Batch` auto-commits at 450 ops to respect Firestore's 500-operation limit
- Batch `set/update/delete` are now async to support auto-flush

## Test plan
- [x] 6 new tests in `bulk_write_test.py` (basic, explicit IDs, auto-split 550 items, nested batch error, empty list, batch auto-split)
- [x] All 111 existing tests pass
- [x] Ruff linter and formatter clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)