### PR TITLE
handle messages without attributes key

### DIFF
--- a/gcp_pilot/pubsub.py
+++ b/gcp_pilot/pubsub.py
@@ -480,7 +480,7 @@ class Message:
 
         return Message(
             id=body["message"]["messageId"],
-            attributes=body["message"]["attributes"],
+            attributes=body["message"].get("attributes", {}),
             subscription=body["subscription"],
             data=parser(base64.b64decode(body["message"]["data"]).decode("utf-8")),
         )


### PR DESCRIPTION
attributes key is only set in messages that have declared attributes

if attributes are unused this load function fails due to a missing key error